### PR TITLE
feat: add ft_dprintf implementation and related functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ CFLAGS      = -Wall -Wextra -Werror -I./
 # -------------------------------
 LIBFT_DIR   = src/libft
 PRINTF_DIR  = src/ft_printf
+DPRINTF_DIR  = src/ft_dprintf
 GNL_DIR     = src/get_next_line
 
 # -------------------------------
@@ -75,6 +76,13 @@ FT_PRINTF_SRCS = $(PRINTF_DIR)/ft_printf.c \
                  $(PRINTF_DIR)/ft_number_functions.c \
                  $(PRINTF_DIR)/ft_ptr_functions.c \
                  $(PRINTF_DIR)/ft_string_functions.c
+# -------------------------------
+#   Source for ft_dprintf
+# -------------------------------
+FT_DPRINTF_SRCS = $(DPRINTF_DIR)/ft_dprintf.c \
+				  $(DPRINTF_DIR)/ft_number_functions.c \
+                  $(DPRINTF_DIR)/ft_ptr_functions.c \
+                  $(DPRINTF_DIR)/ft_string_functions.c
 
 # -------------------------------
 #   Source for get_next_line
@@ -85,7 +93,7 @@ GNL_SRCS    = $(GNL_DIR)/get_next_line.c \
 # -------------------------------
 #   Combine all into SRCS
 # -------------------------------
-SRCS        = $(LIBFT_SRCS) $(FT_PRINTF_SRCS) $(GNL_SRCS)
+SRCS        = $(LIBFT_SRCS) $(FT_PRINTF_SRCS) $(FT_DPRINTF_SRCS) $(GNL_SRCS)
 
 # -------------------------------
 #   Convert .c files to .o
@@ -97,6 +105,7 @@ OBJS        = $(SRCS:.c=.o)
 # -------------------------------
 HEADERS     = libft.h \
               ft_printf.h \
+              ft_dprintf.h \
               get_next_line.h
 
 # -------------------------------

--- a/ft_dprintf.h
+++ b/ft_dprintf.h
@@ -1,0 +1,26 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_dprintf.h                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/18 12:18:42 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/05/18 19:14:15 by dsemenov         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef FT_DPRINTF_H
+# define FT_DPRINTF_H
+
+# include <unistd.h>
+
+int				ft_dprintf(int fd, const char *format, ...);
+ssize_t			ft_putchar_fd(int fd, char c);
+ssize_t			ft_dputstr(int fd, char *s);
+ssize_t			ft_dputnbr(int fd, int n);
+ssize_t			ft_unsigned_dputnbr(int fd, unsigned int n);
+ssize_t			ft_dputhex(int fd, unsigned long nbr, const char *base);
+ssize_t			ft_dputptr(int fd, void *ptr);
+
+#endif

--- a/src/ft_dprintf/ft_dprintf.c
+++ b/src/ft_dprintf/ft_dprintf.c
@@ -1,0 +1,80 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_dprintf.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/18 12:17:03 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/05/18 19:15:53 by dsemenov         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_dprintf.h"
+#include <stdarg.h>
+#include <unistd.h>
+
+static ssize_t	ft_process(int fd, const char **format, va_list args);
+static int		ft_parse(int fd, va_list args, const char c);
+
+int	ft_dprintf(int fd, const char *format, ...)
+{
+	ssize_t	len;
+	ssize_t	result;
+	va_list	args;
+
+	len = 0;
+	if (!format)
+	{
+		return (-1);
+	}
+	va_start(args, format);
+	while (*format)
+	{
+		result = ft_process(fd, &format, args);
+		if (result == -1)
+		{
+			va_end(args);
+			return (-1);
+		}
+		len += result;
+		format++;
+	}
+	va_end(args);
+	return (len);
+}
+
+static ssize_t	ft_process(int fd, const char **format, va_list args)
+{
+	if (**format != '%')
+		return (ft_putchar_fd(fd, **format));
+	(*format)++;
+	if (**format == '%')
+		return (ft_putchar_fd(fd, '%'));
+	return (ft_parse(fd, args, **format));
+}
+
+static int	ft_parse(int fd, va_list args, const char c)
+{
+	ssize_t	res;
+
+	if (c == 'c')
+		res = ft_putchar_fd(fd, va_arg(args, int));
+	else if (c == 's')
+		res = ft_dputstr(fd, va_arg(args, char *));
+	else if (c == 'd' || c == 'i')
+		res = ft_dputnbr(fd, va_arg(args, int));
+	else if (c == 'u')
+		res = ft_unsigned_dputnbr(fd, va_arg(args, unsigned int));
+	else if (c == 'x')
+		res = ft_dputhex(fd, va_arg(args, unsigned int), "0123456789abcdef");
+	else if (c == 'X')
+		res = ft_dputhex(fd, va_arg(args, unsigned int), "0123456789ABCDEF");
+	else if (c == 'p')
+		res = ft_dputptr(fd, va_arg(args, void *));
+	else
+		res = 0;
+	if (res == -1)
+		return (-1);
+	return (res);
+}

--- a/src/ft_dprintf/ft_number_functions.c
+++ b/src/ft_dprintf/ft_number_functions.c
@@ -1,0 +1,94 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_number_functions.c                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/18 14:53:38 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/05/18 19:16:40 by dsemenov         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_dprintf.h"
+#include <unistd.h>
+
+static ssize_t	ft_dputnbr_recursive(int fd, unsigned int nbr)
+{
+	ssize_t	len;
+	ssize_t	res;
+
+	len = 0;
+	if (nbr >= 10)
+	{
+		res = ft_dputnbr_recursive(fd, (nbr / 10));
+		if (res == -1)
+			return (-1);
+		len += res;
+	}
+	if (ft_putchar_fd(fd, (nbr % 10) + '0') == -1)
+		return (-1);
+	len += 1;
+	return (len);
+}
+
+ssize_t	ft_dputnbr(int fd, int n)
+{
+	ssize_t			len;
+	unsigned int	nbr;
+
+	len = 0;
+	if (n == -2147483648)
+		return (ft_dputstr(fd, "-2147483648"));
+	if (n < 0)
+	{
+		if (ft_putchar_fd(fd, '-') == -1)
+			return (-1);
+		nbr = -n;
+		len += 1;
+	}
+	else
+		nbr = n;
+	len += ft_dputnbr_recursive(fd, nbr);
+	if (len == -1)
+		return (-1);
+	return (len);
+}
+
+ssize_t	ft_dputhex(int fd, unsigned long nbr, const char *base)
+{
+	ssize_t	len;
+	ssize_t	res;
+
+	len = 0;
+	if (nbr >= 16)
+	{
+		res = ft_dputhex(fd, (nbr / 16), base);
+		if (res == -1)
+			return (-1);
+		len += res;
+	}
+	if (ft_putchar_fd(fd, (base[nbr % 16])) == -1)
+		return (-1);
+	len += 1;
+	return (len);
+}
+
+ssize_t	ft_unsigned_dputnbr(int fd, unsigned int nbr)
+{
+	ssize_t	len;
+	ssize_t	res;
+
+	len = 0;
+	if (nbr >= 10)
+	{
+		res = ft_unsigned_dputnbr(fd, (nbr / 10));
+		if (res == -1)
+			return (-1);
+		len += res;
+	}
+	if (ft_putchar_fd(fd, ((nbr % 10) + '0') == -1))
+		return (-1);
+	len += 1;
+	return (len);
+}

--- a/src/ft_dprintf/ft_ptr_functions.c
+++ b/src/ft_dprintf/ft_ptr_functions.c
@@ -1,0 +1,33 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_ptr_functions.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/18 15:39:16 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/05/18 19:13:50 by dsemenov         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_dprintf.h"
+#include <stddef.h>
+#include <unistd.h>
+
+ssize_t	ft_dputptr(int fd, void *ptr)
+{
+	ssize_t	len;
+	ssize_t	res;
+
+	len = 0;
+	if (ptr == NULL)
+		return (ft_dputstr(fd, "(nil)"));
+	len = ft_dputstr(fd, "0x");
+	if (len == -1)
+		return (-1);
+	res = ft_dputhex(fd, (unsigned long)ptr, "0123456789abcdef");
+	if (res == -1)
+		return (-1);
+	len += res;
+	return (len);
+}

--- a/src/ft_dprintf/ft_string_functions.c
+++ b/src/ft_dprintf/ft_string_functions.c
@@ -1,0 +1,39 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_string_functions.c                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/18 13:49:03 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/05/18 19:14:26 by dsemenov         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <unistd.h>
+
+ssize_t	ft_putchar_fd(int fd, char c)
+{
+	if (write(fd, &c, 1) == -1)
+		return (-1);
+	return (1);
+}
+
+ssize_t	ft_dputstr(int fd, char *s)
+{
+	ssize_t	len;
+	ssize_t	result;
+
+	len = 0;
+	if (!s)
+		s = "(null)";
+	while (*s)
+	{
+		result = ft_putchar_fd(fd, *s);
+		if (result == -1)
+			return (-1);
+		len += result;
+		s++;
+	}
+	return (len);
+}


### PR DESCRIPTION
This pull request introduces a new `ft_dprintf` functionality, which is a file descriptor-based variant of `ft_printf`. It includes updates to the `Makefile` to integrate the new module and adds several new files implementing the `ft_dprintf` functionality. Below are the key changes grouped by theme:

### Build System Updates
* Added `DPRINTF_DIR` to the `Makefile` to include the new `ft_dprintf` directory.
* Defined `FT_DPRINTF_SRCS` in the `Makefile` to specify the source files related to `ft_dprintf`.
* Updated the `SRCS` variable in the `Makefile` to include `FT_DPRINTF_SRCS`.
* Added `ft_dprintf.h` to the `HEADERS` list in the `Makefile`.

### New `ft_dprintf` Implementation
* Introduced the `ft_dprintf.h` header, which declares the main `ft_dprintf` function and its helper functions.
* Added the main implementation of `ft_dprintf` in `ft_dprintf.c`, including parsing and processing logic for various format specifiers.

### Supporting Functions for `ft_dprintf`
* Implemented number-related helper functions in `ft_number_functions.c`, such as `ft_dputnbr`, `ft_unsigned_dputnbr`, and `ft_dputhex`.
* Added pointer formatting support in `ft_ptr_functions.c` with the `ft_dputptr` function.
* Implemented string and character output functions in `ft_string_functions.c`, including `ft_putchar_fd` and `ft_dputstr`.