### PR TITLE
Strtod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ GNL_DIR     = src/get_next_line
 LIBFT_SRCS  = $(LIBFT_DIR)/ft_atoi.c \
               $(LIBFT_DIR)/ft_atol.c \
               $(LIBFT_DIR)/ft_atoi_hex.c \
+              $(LIBFT_DIR)/ft_strtod.c \
               $(LIBFT_DIR)/ft_bzero.c \
               $(LIBFT_DIR)/ft_calloc.c \
               $(LIBFT_DIR)/ft_isalnum.c \

--- a/libft.h
+++ b/libft.h
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/09 14:14:34 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/24 12:15:34 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/10/31 23:18:37 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,14 @@
 
 # include <stddef.h>
 # include <unistd.h>
+
+typedef struct s_strtod_state
+{
+	long double		m;
+	int				frac;
+	int				exp10;
+	int				has;
+}					t_strtod_state;
 
 typedef struct s_list
 {
@@ -47,6 +55,7 @@ char				*ft_strndup(const char *s, size_t n);
 int					ft_atoi(const char *nptr);
 long				ft_atol(const char *nptr);
 int					ft_atoi_hex(const char *str);
+double				ft_strtod(const char *nptr, char **endptr);
 char				*ft_strchr(const char *s, int c);
 char				*ft_strrchr(const char *s, int c);
 int					ft_strcmp(const char *s1, const char *s2);

--- a/src/libft/ft_strtod.c
+++ b/src/libft/ft_strtod.c
@@ -1,0 +1,119 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_strtod.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/10/31 23:10:42 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/10/31 23:22:27 by tsargsya         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+static double	ft_pow10(int exp)
+{
+	double	res;
+
+	res = 1.0;
+	if (exp > 0)
+	{
+		while (exp-- > 0)
+			res *= 10.0;
+	}
+	else if (exp < 0)
+	{
+		while (exp++ < 0)
+			res /= 10.0;
+	}
+	return (res);
+}
+
+static const char	*read_digits(
+	const char *p,
+	long double *m,
+	int *cnt,
+	int *has)
+{
+	while (*p && ft_isdigit((unsigned char)*p))
+	{
+		*m = (*m * 10.0L) + (long double)(*p - '0');
+		p++;
+		if (cnt)
+			(*cnt)++;
+		*has = 1;
+	}
+	return (p);
+}
+
+static const char	*read_exp(const char *p, int has_digits, int *exp10)
+{
+	const char	*save;
+	int			expsign;
+	int			expval;
+
+	if (!(has_digits && (*p == 'e' || *p == 'E')))
+		return (p);
+	save = p;
+	p++;
+	expsign = 1;
+	if (*p == '+' || *p == '-')
+	{
+		if (*p == '-')
+			expsign = -1;
+		p++;
+	}
+	expval = 0;
+	if (!ft_isdigit((unsigned char)*p))
+		return (save);
+	while (*p && ft_isdigit((unsigned char)*p))
+	{
+		expval = (expval * 10) + (*p - '0');
+		p++;
+	}
+	*exp10 += expsign * expval;
+	return (p);
+}
+
+static const char	*read_ws_sign(const char *p, int *sign)
+{
+	while (*p && ft_isspace((unsigned char)*p))
+		p++;
+	*sign = 1;
+	if (*p == '+' || *p == '-')
+	{
+		if (*p == '-')
+			*sign = -1;
+		p++;
+	}
+	return (p);
+}
+
+double	ft_strtod(const char *nptr, char **endptr)
+{
+	const char				*p;
+	int						sign;
+	t_strtod_state			s;
+
+	p = read_ws_sign(nptr, &sign);
+	s.m = 0.0L;
+	s.frac = 0;
+	s.has = 0;
+	p = read_digits(p, &s.m, NULL, &s.has);
+	if (*p == '.')
+	{
+		p = read_digits(p + 1, &s.m, &s.frac, &s.has);
+	}
+	s.exp10 = -s.frac;
+	p = read_exp(p, s.has, &s.exp10);
+	if (!s.has)
+	{
+		if (endptr)
+			*endptr = (char *)nptr;
+		return (0.0);
+	}
+	if (endptr)
+		*endptr = (char *)p;
+	return ((double)(sign * s.m * (long double)ft_pow10(s.exp10)));
+}

--- a/src/libft/ft_strtod.c
+++ b/src/libft/ft_strtod.c
@@ -6,114 +6,112 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/31 23:10:42 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/10/31 23:22:27 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/11/01 00:03:13 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-static double	ft_pow10(int exp)
+static double	ft_pow10(int exponent)
 {
-	double	res;
+	double	result;
 
-	res = 1.0;
-	if (exp > 0)
+	result = 1.0;
+	if (exponent > 0)
 	{
-		while (exp-- > 0)
-			res *= 10.0;
+		while (exponent-- > 0)
+			result *= 10.0;
 	}
-	else if (exp < 0)
+	else if (exponent < 0)
 	{
-		while (exp++ < 0)
-			res /= 10.0;
+		while (exponent++ < 0)
+			result /= 10.0;
 	}
-	return (res);
+	return (result);
 }
 
-static const char	*read_digits(
-	const char *p,
-	long double *m,
-	int *cnt,
-	int *has)
+static const char	*read_digits(const char *str_pointer,
+								long double *mantissa,
+								int *count, int *has_digits)
 {
-	while (*p && ft_isdigit((unsigned char)*p))
+	while (*str_pointer && ft_isdigit((unsigned char)*str_pointer))
 	{
-		*m = (*m * 10.0L) + (long double)(*p - '0');
-		p++;
-		if (cnt)
-			(*cnt)++;
-		*has = 1;
+		*mantissa = (*mantissa * 10.0L) + (long double)(*str_pointer - '0');
+		str_pointer++;
+		if (count)
+			(*count)++;
+		*has_digits = 1;
 	}
-	return (p);
+	return (str_pointer);
 }
 
-static const char	*read_exp(const char *p, int has_digits, int *exp10)
+static const char	*read_exp(const char *pointer, int has_digits, int *exp10)
 {
 	const char	*save;
-	int			expsign;
-	int			expval;
+	int			exponent_sign;
+	int			exponent_value;
 
-	if (!(has_digits && (*p == 'e' || *p == 'E')))
-		return (p);
-	save = p;
-	p++;
-	expsign = 1;
-	if (*p == '+' || *p == '-')
+	if (!(has_digits && (*pointer == 'e' || *pointer == 'E')))
+		return (pointer);
+	save = pointer;
+	pointer++;
+	exponent_sign = 1;
+	if (*pointer == '+' || *pointer == '-')
 	{
-		if (*p == '-')
-			expsign = -1;
-		p++;
+		if (*pointer == '-')
+			exponent_sign = -1;
+		pointer++;
 	}
-	expval = 0;
-	if (!ft_isdigit((unsigned char)*p))
+	exponent_value = 0;
+	if (!ft_isdigit((unsigned char)*pointer))
 		return (save);
-	while (*p && ft_isdigit((unsigned char)*p))
+	while (*pointer && ft_isdigit((unsigned char)*pointer))
 	{
-		expval = (expval * 10) + (*p - '0');
-		p++;
+		exponent_value = (exponent_value * 10) + (*pointer - '0');
+		pointer++;
 	}
-	*exp10 += expsign * expval;
-	return (p);
+	*exp10 += exponent_sign * exponent_value;
+	return (pointer);
 }
 
-static const char	*read_ws_sign(const char *p, int *sign)
+static const char	*read_ws_sign(const char *pointer, int *sign)
 {
-	while (*p && ft_isspace((unsigned char)*p))
-		p++;
+	while (*pointer && ft_isspace((unsigned char)*pointer))
+		pointer++;
 	*sign = 1;
-	if (*p == '+' || *p == '-')
+	if (*pointer == '+' || *pointer == '-')
 	{
-		if (*p == '-')
+		if (*pointer == '-')
 			*sign = -1;
-		p++;
+		pointer++;
 	}
-	return (p);
+	return (pointer);
 }
 
 double	ft_strtod(const char *nptr, char **endptr)
 {
-	const char				*p;
-	int						sign;
-	t_strtod_state			s;
+	const char		*pointer;
+	int				sign;
+	t_strtod_state	state;
 
-	p = read_ws_sign(nptr, &sign);
-	s.m = 0.0L;
-	s.frac = 0;
-	s.has = 0;
-	p = read_digits(p, &s.m, NULL, &s.has);
-	if (*p == '.')
+	pointer = read_ws_sign(nptr, &sign);
+	state.m = 0.0L;
+	state.frac = 0;
+	state.has = 0;
+	pointer = read_digits(pointer, &state.m, NULL, &state.has);
+	if (*pointer == '.')
 	{
-		p = read_digits(p + 1, &s.m, &s.frac, &s.has);
+		pointer = read_digits(pointer + 1, &state.m, &state.frac, &state.has);
 	}
-	s.exp10 = -s.frac;
-	p = read_exp(p, s.has, &s.exp10);
-	if (!s.has)
+	state.exp10 = -state.frac;
+	pointer = read_exp(pointer, state.has, &state.exp10);
+	if (!state.has)
 	{
 		if (endptr)
 			*endptr = (char *)nptr;
 		return (0.0);
 	}
 	if (endptr)
-		*endptr = (char *)p;
-	return ((double)(sign * s.m * (long double)ft_pow10(s.exp10)));
+		*endptr = (char *)pointer;
+	return ((double)(sign * state.m * (long double)ft_pow10(state.exp10)));
 }

--- a/tests/libft_tester.c
+++ b/tests/libft_tester.c
@@ -17,6 +17,27 @@
 		}                                              \
 	} while (0)
 
+// Small helper for approximate double comparison without libm dependency
+static int approx_eq(double a, double b, double eps)
+{
+	double diff;
+	double aa;
+	double bb;
+	double scale;
+
+	diff = a - b;
+	if (diff < 0)
+		diff = -diff;
+	aa = a < 0 ? -a : a;
+	bb = b < 0 ? -b : b;
+	scale = 1.0;
+	if (aa > scale)
+		scale = aa;
+	if (bb > scale)
+		scale = bb;
+	return diff <= eps * scale;
+}
+
 // ───────────── CHAR & INT CHECKS ─────────────
 void test_char_checks(void)
 {
@@ -154,6 +175,43 @@ void test_misc(void)
 	ASSERT("ft_count_tokens()", ft_count_tokens(tokens) == 3);
 }
 
+// ───────────── STRTOD ─────────────
+void test_strtod(void)
+{
+	char *end;
+	const char *s;
+
+	// integers and simple decimals
+	s = "42"; ASSERT("ft_strtod(\"42\") value", approx_eq(ft_strtod(s, &end), 42.0, 1e-12)); ASSERT("endptr at end for '42'", *end == '\0');
+	s = "-3.5"; ASSERT("ft_strtod(\"-3.5\") value", approx_eq(ft_strtod(s, &end), -3.5, 1e-12)); ASSERT("endptr at end for '-3.5'", *end == '\0');
+	s = "+7.25"; ASSERT("ft_strtod(\"+7.25\") value", approx_eq(ft_strtod(s, &end), 7.25, 1e-12)); ASSERT("endptr at end for '+7.25'", *end == '\0');
+
+	// leading/trailing whitespace
+	s = "   12.34  "; ASSERT("ft_strtod with leading spaces", approx_eq(ft_strtod(s, &end), 12.34, 1e-12)); ASSERT("endptr stops before trailing space", *end == ' ');
+
+	// fraction-only or trailing dot
+	s = ".5"; ASSERT("ft_strtod(\".5\") == 0.5", approx_eq(ft_strtod(s, &end), 0.5, 1e-12)); ASSERT("endptr at end for '.5'", *end == '\0');
+	s = "5."; ASSERT("ft_strtod(\"5.\") == 5.0", approx_eq(ft_strtod(s, &end), 5.0, 1e-12)); ASSERT("endptr at end for '5.'", *end == '\0');
+
+	// exponent forms
+	s = "1e3"; ASSERT("ft_strtod(\"1e3\") == 1000", approx_eq(ft_strtod(s, &end), 1000.0, 1e-9)); ASSERT("endptr at end for '1e3'", *end == '\0');
+	s = "1.5e-3"; ASSERT("ft_strtod(\"1.5e-3\") == 0.0015", approx_eq(ft_strtod(s, &end), 0.0015, 1e-12)); ASSERT("endptr at end for '1.5e-3'", *end == '\0');
+	s = "2E+2"; ASSERT("ft_strtod(\"2E+2\") == 200", approx_eq(ft_strtod(s, &end), 200.0, 1e-12)); ASSERT("endptr at end for '2E+2'", *end == '\0');
+
+	// invalid exponent digits: should stop before 'e'
+	s = "1e"; ASSERT("ft_strtod(\"1e\") == 1", approx_eq(ft_strtod(s, &end), 1.0, 1e-12)); ASSERT("endptr points to 'e'", *end == 'e');
+
+	// stop at first non-number
+	s = "12.3xyz"; ASSERT("ft_strtod stops before 'x'", approx_eq(ft_strtod(s, &end), 12.3, 1e-12)); ASSERT("endptr at 'x'", *end == 'x');
+
+	// no digits -> return 0.0 and endptr == nptr
+	s = "abc"; ASSERT("ft_strtod(\"abc\") returns 0.0", approx_eq(ft_strtod(s, &end), 0.0, 1e-12)); ASSERT("endptr == start for no-digits", end == s);
+	s = "   +"; ASSERT("ft_strtod(\"   +\") returns 0.0", approx_eq(ft_strtod(s, &end), 0.0, 1e-12)); ASSERT("endptr == start when only ws+sign", end == s);
+
+	// combined sign, exponent and trailing characters
+	s = "   -0.25e+2xyz"; ASSERT("ft_strtod( '   -0.25e+2xyz' ) == -25.0", approx_eq(ft_strtod(s, &end), -25.0, 1e-12)); ASSERT("endptr at 'x'", *end == 'x');
+}
+
 // ───────────── PRINTF ─────────────
 void test_printf(void)
 {
@@ -195,6 +253,7 @@ int main(void)
 	test_strmapi_iteri();
 	test_lists();
 	test_misc();
+	test_strtod();
     test_printf();
     test_get_next_line();
 


### PR DESCRIPTION
This pull request adds a new function, `ft_strtod`, to the libft library, which parses a string into a double-precision floating point value, similar to the standard C `strtod`. It also introduces comprehensive unit tests for this function, a supporting struct and helper, and updates the build system and header files accordingly.

### New feature: String to double conversion

* Added the implementation of `ft_strtod` in `src/libft/ft_strtod.c`, supporting whitespace, sign, decimal, and exponent notation, and handling invalid input gracefully.
* Declared the `ft_strtod` function in `libft.h` and added the supporting `t_strtod_state` struct for internal parsing state. [[1]](diffhunk://#diff-abb24bcc6f4139295ba81afec8f45d368984dbec6d32ff14a64238c0faecc2eeR58) [[2]](diffhunk://#diff-abb24bcc6f4139295ba81afec8f45d368984dbec6d32ff14a64238c0faecc2eeR19-R26)

### Build system and header updates

* Included `ft_strtod.c` in the list of sources in `Makefile` to ensure it is compiled as part of the library.
* Updated the header file comment with the latest modification date.

### Testing enhancements

* Added a helper function, `approx_eq`, for approximate double comparison in tests without external dependencies.
* Implemented a thorough test suite for `ft_strtod` in `tests/libft_tester.c`, covering edge cases, valid/invalid input, exponent handling, and correct `endptr` behavior.
* Integrated the new test suite into the main test runner.